### PR TITLE
Fix interface conversion from int types to float64

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -950,7 +950,8 @@ func jsonToValue(i *interpreter, v interface{}) (value, error) {
 	case bool:
 		return makeValueBoolean(v), nil
 	case int, int8, int16, int32, int64:
-		return makeDoubleCheck(i, v.(float64))
+		val, _ := v.(int64)
+		return makeDoubleCheck(i, float64(val))
 	case float64:
 		return makeDoubleCheck(i, v)
 


### PR DESCRIPTION
This pull request is based on https://github.com/google/go-jsonnet/pull/741

- https://github.com/google/go-jsonnet/pull/741

I cherry picked the commit https://github.com/google/go-jsonnet/pull/741/commits/ef930fd8a51c5e86201137b0003500eb1a69e84b .